### PR TITLE
Docs deps

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,13 +3,8 @@ version: 2
 python:
   version: 3.6
   install:
-    - method: pip
-      path: .
-      # https://github.com/readthedocs/readthedocs.org/issues/4912
-      # won't install poetry dev packages, need docs/source/requirements.txt
-      # generate using poetry run pip freeze > docs/source/requirements.txt
-      extra_requirements:
-        - docs/source
+      requirements:
+        - docs/source/requirements.txt
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,10 +3,8 @@ version: 2
 python:
   version: 3.6
   install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs/source/requirements.txt
+    - requirements: docs/source/requirements.txt
+    - path: .
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,8 +3,7 @@ version: 2
 python:
   version: 3.6
   install:
-      requirements:
-        - docs/source/requirements.txt
+      - requirements: docs/source/requirements.txt
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,11 @@ python:
   install:
     - method: pip
       path: .
+      # https://github.com/readthedocs/readthedocs.org/issues/4912
+      # won't install poetry dev packages, need docs/source/requirements.txt
+      # generate using poetry run pip freeze > docs/source/requirements.txt
       extra_requirements:
-        - docs
+        - docs/source
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,10 @@ version: 2
 python:
   version: 3.6
   install:
-      - requirements: docs/source/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs/source/requirements.txt
 
 sphinx:
   configuration: docs/source/conf.py

--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -67,6 +67,11 @@ poetry run task isort
 poetry run task build_docs
 ```
 
+https://docs.readthedocs.io/ issue with poetry and dev deps.
+https://github.com/readthedocs/readthedocs.org/issues/4912
+won't install poetry dev packages, need docs/source/requirements.txt
+generate using poetry run pip freeze > docs/source/requirements.txt
+
 #### Version management
 ```bash
 # pass args e.g. patch, minor, major

--- a/docs/source/dev.md
+++ b/docs/source/dev.md
@@ -76,6 +76,8 @@ poetry run bumpversion --commit --tag patch
 poetry run task tests
 poetry run task ci_lint
 poetry run bumpversion --commit --tag patch
+git push
+git push --tags
 
 poetry config repositories.testpypi https://test.pypi.org/legacy/
 poetry publish --build --repository testpypi

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,0 +1,10 @@
+Sphinx==3.0.3
+sphinx-autobuild==0.7.1
+sphinx-autodoc-typehints==1.10.3
+sphinx-rtd-theme==0.4.3
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==1.0.3
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,17 +28,17 @@ black = { version = "*", allow-prereleases = true }
 bump2version = "*"
 docker = "*"
 isort = { version = "*", extras = ["poetry"] }
+mypy = "^0.780"
 pytest = "*"
 recommonmark = "*"
 sphinx = "*"
 sphinx-autobuild = "*"
+sphinx_rtd_theme = "^0.4.3"
+sphinx-autodoc-typehints = "^1.10.3"
 taskipy = "*"
 
 # https://github.com/python-poetry/poetry/issues/241
 # dev scripts
-sphinx_rtd_theme = "^0.4.3"
-sphinx-autodoc-typehints = "^1.10.3"
-mypy = "^0.780"
 [tool.taskipy.tasks]
 build_docs = "sphinx-autobuild docs/source docs/build/html"
 bumpversion = "bumpversion"


### PR DESCRIPTION
Finally fixed docs by looking at [scrapy's config](https://github.com/scrapy/scrapy/blob/3d027fb578532d504b3dbfaa77a06c3560f85d3c/.readthedocs.yml#L11)

Had to pip freeze, remove everything except sphinx stuff, install directly on RTD with local path included too.

**Changes**
1. Fix RTD docs build
    1. Add explicit requirements.txt to docs/source
    2. Update rtd config
2. Add notes on pushing tag
3. Sort deps in pyproject.toml